### PR TITLE
Add FriendlyElec NanoPi R5S running kernel 6.1.0

### DIFF
--- a/Results.md
+++ b/Results.md
@@ -82,6 +82,7 @@ So do **not** rely on collected numbers unless you carefully read through all th
 | [NanoPi NEO4](http://ix.io/1oim) | 2000/1500 MHz | 4.4| Stretch arm64 | 6520 | 1718 | 1123190 | 2280 | 4770 | 8.83 |
 | [NanoPi NEO4](http://ix.io/1p3T) | 2000/1500 MHz | 4.19 | Stretch arm64 | 6750 | 1814 | 1139850 | 2370 | 6110 | 8.84 |
 | [NanoPi NEO4](http://ix.io/3GmR) | 2016/1512 MHz | 5.10 | Focal arm64 | 6970 | 1906 | 1145030 | 2450 | 6190 | 11.36 |
+| [NanoPi R5S](http://ix.io/4jfZ) | 1992 MHz | 6.1 | Bullseye arm64 | 5030 | 1482 | 914340 | 2990 | 5970 | 7.33 |
 | [Nintendo Switch](http://ix.io/1Rnj) | 1780 MHz | 4.9 | **Fedora 30 arm-64** | 6170 | 1719 | 642670 | 2500 | 3570 | - |
 | [Nintendo Switch](http://ix.io/3Di2) | 2060 MHz | 4.9 | Bionic arm64 | 6720 | 1901 | 746680 | 2370 | 3670 | 9.25 |
 | [ODROID-C1](http://ix.io/4eg5) | 1500 MHz | 5.19 | Jammy armhf | 3010 | 878 | 29260 | 390 | 2910 | - |

--- a/Results.md
+++ b/Results.md
@@ -82,7 +82,7 @@ So do **not** rely on collected numbers unless you carefully read through all th
 | [NanoPi NEO4](http://ix.io/1oim) | 2000/1500 MHz | 4.4| Stretch arm64 | 6520 | 1718 | 1123190 | 2280 | 4770 | 8.83 |
 | [NanoPi NEO4](http://ix.io/1p3T) | 2000/1500 MHz | 4.19 | Stretch arm64 | 6750 | 1814 | 1139850 | 2370 | 6110 | 8.84 |
 | [NanoPi NEO4](http://ix.io/3GmR) | 2016/1512 MHz | 5.10 | Focal arm64 | 6970 | 1906 | 1145030 | 2450 | 6190 | 11.36 |
-| [NanoPi R5S](http://ix.io/4jfZ) | 1992 MHz | 6.1 | Bullseye arm64 | 5030 | 1482 | 914340 | 2990 | 5970 | 7.33 |
+| [NanoPi R5S](http://ix.io/4jfZ) | 1960 MHz | 6.1 | Bullseye arm64 | 5030 | 1482 | 914340 | 2990 | 5970 | 7.33 |
 | [Nintendo Switch](http://ix.io/1Rnj) | 1780 MHz | 4.9 | **Fedora 30 arm-64** | 6170 | 1719 | 642670 | 2500 | 3570 | - |
 | [Nintendo Switch](http://ix.io/3Di2) | 2060 MHz | 4.9 | Bionic arm64 | 6720 | 1901 | 746680 | 2370 | 3670 | 9.25 |
 | [ODROID-C1](http://ix.io/4eg5) | 1500 MHz | 5.19 | Jammy armhf | 3010 | 878 | 29260 | 390 | 2910 | - |

--- a/results/4jfZ.txt
+++ b/results/4jfZ.txt
@@ -1,0 +1,755 @@
+sbc-bench v0.9.9 FriendlyElec NanoPi R5S (Thu, 22 Dec 2022 05:06:14 -0500)
+
+Distributor ID:	Debian
+Description:	Debian GNU/Linux 11 (bullseye)
+Release:	11
+Codename:	bullseye
+
+/usr/bin/gcc (Debian 10.2.1-6) 10.2.1 20210110
+
+Uptime: 05:06:14 up 1 day,  9:53,  1 user,  load average: 1.70, 0.85, 0.40,  43.8°C,  288962608
+
+Linux 6.1.0 (nanopir5s) 	12/22/22 	_aarch64_	(4 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.06    0.00    0.05    0.00    0.00   99.90
+
+Device             tps    kB_read/s    kB_wrtn/s    kB_dscd/s    kB_read    kB_wrtn    kB_dscd
+mmcblk1           0.12         2.23         1.75       107.69     272026     213305   13136992
+zram0             0.00         0.01         0.00         0.00       1304          4          0
+
+               total        used        free      shared  buff/cache   available
+Mem:           3.7Gi       160Mi       3.4Gi        14Mi        77Mi       3.4Gi
+Swap:          1.0Gi          0B       1.0Gi
+
+Filename				Type		Size	Used	Priority
+/dev/zram0                             	partition	1048572	0	100
+
+WARNING: ZSWAP ON TOP OF ZRAM HAS BEEN CONFIGURED ON THIS SYSTEM!
+THIS WILL SEVERELY HARM PERFORMANCE IN CASE SWAPPING OCCURS!
+
+Zswap active using lzo/zbud, max pool occupation: 20%, details:
+	duplicate_entry:0
+	pool_limit_hit:0
+	pool_total_size:0
+	reject_alloc_fail:0
+	reject_compress_poor:0
+	reject_kmemcache_fail:0
+	reject_reclaim_fail:0
+	same_filled_pages:0
+	stored_pages:0
+	written_back_pages:0
+
+##########################################################################
+
+Checking cpufreq OPP (Cortex-A55):
+
+Cpufreq OPP: 1992    Measured: 1964 (1964.542/1964.449/1963.982)     (-1.4%)
+Cpufreq OPP: 1800    Measured: 1801 (1801.312/1801.037/1800.841)
+Cpufreq OPP: 1608    Measured: 1656 (1656.658/1656.525/1655.828)     (+3.0%)
+Cpufreq OPP: 1416    Measured: 1425 (1425.793/1425.424/1424.748)
+Cpufreq OPP: 1104    Measured: 1314 (1314.753/1314.459/1314.165)    (+19.0%)
+Cpufreq OPP:  816    Measured:  810    (810.206/810.186/809.934)
+Cpufreq OPP:  600    Measured:  594    (594.403/594.103/593.947)
+Cpufreq OPP:  408    Measured:  402    (402.265/402.172/402.088)     (-1.5%)
+
+##########################################################################
+
+Hardware sensors:
+
+gpu_thermal-virtual-0
+temp1:        +39.4 C  (crit = +95.0 C)
+
+cpu_thermal-virtual-0
+temp1:        +42.5 C  (crit = +95.0 C)
+
+##########################################################################
+
+Executing benchmark on cpu0 (Cortex-A55):
+
+tinymembench v0.4.9 (simple benchmark for memory throughput and latency)
+
+==========================================================================
+== Memory bandwidth tests                                               ==
+==                                                                      ==
+== Note 1: 1MB = 1000000 bytes                                          ==
+== Note 2: Results for 'copy' tests show how many bytes can be          ==
+==         copied per second (adding together read and writen           ==
+==         bytes would have provided twice higher numbers)              ==
+== Note 3: 2-pass copy means that we are using a small temporary buffer ==
+==         to first fetch data into it, and only then write it to the   ==
+==         destination (source -> L1 cache, L1 cache -> destination)    ==
+== Note 4: If sample standard deviation exceeds 0.1%, it is shown in    ==
+==         brackets                                                     ==
+==========================================================================
+
+ C copy backwards                                     :   2126.2 MB/s (2.7%)
+ C copy backwards (32 byte blocks)                    :   2001.7 MB/s
+ C copy backwards (64 byte blocks)                    :   1435.5 MB/s
+ C copy                                               :   3000.7 MB/s
+ C copy prefetched (32 bytes step)                    :   1811.6 MB/s
+ C copy prefetched (64 bytes step)                    :   2206.1 MB/s (0.1%)
+ C 2-pass copy                                        :   2282.3 MB/s
+ C 2-pass copy prefetched (32 bytes step)             :   1340.0 MB/s (0.9%)
+ C 2-pass copy prefetched (64 bytes step)             :   1510.7 MB/s
+ C fill                                               :   5969.6 MB/s
+ C fill (shuffle within 16 byte blocks)               :   5968.2 MB/s
+ C fill (shuffle within 32 byte blocks)               :   5968.4 MB/s
+ C fill (shuffle within 64 byte blocks)               :   5967.1 MB/s
+ ---
+ standard memcpy                                      :   2990.3 MB/s
+ standard memset                                      :   5971.0 MB/s
+ ---
+ NEON LDP/STP copy                                    :   2998.0 MB/s
+ NEON LDP/STP copy pldl2strm (32 bytes step)          :   2290.9 MB/s
+ NEON LDP/STP copy pldl2strm (64 bytes step)          :   2791.5 MB/s
+ NEON LDP/STP copy pldl1keep (32 bytes step)          :   2300.0 MB/s
+ NEON LDP/STP copy pldl1keep (64 bytes step)          :   3035.4 MB/s
+ NEON LD1/ST1 copy                                    :   2996.9 MB/s
+ NEON STP fill                                        :   5975.1 MB/s
+ NEON STNP fill                                       :   2183.3 MB/s (0.3%)
+ ARM LDP/STP copy                                     :   2997.9 MB/s
+ ARM STP fill                                         :   5972.9 MB/s
+ ARM STNP fill                                        :   2177.5 MB/s (0.5%)
+
+==========================================================================
+== Framebuffer read tests.                                              ==
+==                                                                      ==
+== Many ARM devices use a part of the system memory as the framebuffer, ==
+== typically mapped as uncached but with write-combining enabled.       ==
+== Writes to such framebuffers are quite fast, but reads are much       ==
+== slower and very sensitive to the alignment and the selection of      ==
+== CPU instructions which are used for accessing memory.                ==
+==                                                                      ==
+== Many x86 systems allocate the framebuffer in the GPU memory,         ==
+== accessible for the CPU via a relatively slow PCI-E bus. Moreover,    ==
+== PCI-E is asymmetric and handles reads a lot worse than writes.       ==
+==                                                                      ==
+== If uncached framebuffer reads are reasonably fast (at least 100 MB/s ==
+== or preferably >300 MB/s), then using the shadow framebuffer layer    ==
+== is not necessary in Xorg DDX drivers, resulting in a nice overall    ==
+== performance improvement. For example, the xf86-video-fbturbo DDX     ==
+== uses this trick.                                                     ==
+==========================================================================
+
+ NEON LDP/STP copy (from framebuffer)                 :   2909.7 MB/s
+ NEON LDP/STP 2-pass copy (from framebuffer)          :   2234.1 MB/s
+ NEON LD1/ST1 copy (from framebuffer)                 :   2913.7 MB/s
+ NEON LD1/ST1 2-pass copy (from framebuffer)          :   2211.5 MB/s
+ ARM LDP/STP copy (from framebuffer)                  :   2910.5 MB/s
+ ARM LDP/STP 2-pass copy (from framebuffer)           :   2235.9 MB/s
+
+==========================================================================
+== Memory latency test                                                  ==
+==                                                                      ==
+== Average time is measured for random memory accesses in the buffers   ==
+== of different sizes. The larger is the buffer, the more significant   ==
+== are relative contributions of TLB, L1/L2 cache misses and SDRAM      ==
+== accesses. For extremely large buffer sizes we are expecting to see   ==
+== page table walk with several requests to SDRAM for almost every      ==
+== memory access (though 64MiB is not nearly large enough to experience ==
+== this effect to its fullest).                                         ==
+==                                                                      ==
+== Note 1: All the numbers are representing extra time, which needs to  ==
+==         be added to L1 cache latency. The cycle timings for L1 cache ==
+==         latency can be usually found in the processor documentation. ==
+== Note 2: Dual random read means that we are simultaneously performing ==
+==         two independent memory accesses at a time. In the case if    ==
+==         the memory subsystem can't handle multiple outstanding       ==
+==         requests, dual random read has the same timings as two       ==
+==         single reads performed one after another.                    ==
+==========================================================================
+
+block size : single random read / dual random read, [MADV_NOHUGEPAGE]
+      1024 :    0.0 ns          /     0.0 ns 
+      2048 :    0.0 ns          /     0.0 ns 
+      4096 :    0.0 ns          /     0.0 ns 
+      8192 :    0.0 ns          /     0.0 ns 
+     16384 :    0.3 ns          /     0.6 ns 
+     32768 :    3.3 ns          /     5.7 ns 
+     65536 :    9.3 ns          /    13.3 ns 
+    131072 :   12.3 ns          /    16.2 ns 
+    262144 :   14.6 ns          /    17.6 ns 
+    524288 :   19.7 ns          /    23.2 ns 
+   1048576 :   86.3 ns          /   129.0 ns 
+   2097152 :  121.2 ns          /   162.3 ns 
+   4194304 :  139.7 ns          /   174.9 ns 
+   8388608 :  156.4 ns          /   189.4 ns 
+  16777216 :  166.3 ns          /   198.5 ns 
+  33554432 :  172.2 ns          /   205.7 ns 
+  67108864 :  177.0 ns          /   209.8 ns 
+
+block size : single random read / dual random read, [MADV_HUGEPAGE]
+      1024 :    0.0 ns          /     0.0 ns 
+      2048 :    0.0 ns          /     0.0 ns 
+      4096 :    0.0 ns          /     0.0 ns 
+      8192 :    0.0 ns          /     0.0 ns 
+     16384 :    0.3 ns          /     0.6 ns 
+     32768 :    3.4 ns          /     5.8 ns 
+     65536 :    9.2 ns          /    13.3 ns 
+    131072 :   12.3 ns          /    16.2 ns 
+    262144 :   14.7 ns          /    17.6 ns 
+    524288 :   19.7 ns          /    23.4 ns 
+   1048576 :   86.3 ns          /   128.9 ns 
+   2097152 :  121.1 ns          /   162.4 ns 
+   4194304 :  138.5 ns          /   173.6 ns 
+   8388608 :  146.8 ns          /   177.7 ns 
+  16777216 :  151.2 ns          /   179.3 ns 
+  33554432 :  153.5 ns          /   179.9 ns 
+  67108864 :  154.6 ns          /   180.2 ns 
+
+##########################################################################
+
+Executing ramlat on cpu0 (Cortex-A55), results in ns:
+
+       size:  1x32  2x32  1x64  2x64 1xPTR 2xPTR 4xPTR 8xPTR
+         4k: 1.532 1.538 1.530 1.541 1.025 1.542 2.085 4.202 
+         8k: 1.530 1.537 1.533 1.538 1.024 1.547 2.085 4.205 
+        16k: 1.531 1.536 1.531 1.539 1.026 1.539 2.087 4.206 
+        32k: 1.580 1.560 1.580 1.559 1.047 1.555 2.107 4.243 
+        64k: 14.77 17.05 14.77 17.06 14.39 17.04 27.49 50.16 
+       128k: 17.51 17.83 17.51 18.04 16.58 17.85 31.30 60.31 
+       256k: 17.98 18.16 17.90 18.17 17.31 18.17 30.96 61.84 
+       512k: 24.19 23.30 20.69 21.06 20.67 20.73 34.35 73.31 
+      1024k: 108.2 129.2 107.4 128.4 110.5 131.8 202.6 337.2 
+      2048k: 139.3 148.9 138.8 148.6 138.8 151.0 219.4 389.1 
+      4096k: 159.2 158.1 153.4 158.3 152.6 159.5 225.4 399.5 
+      8192k: 159.6 164.2 159.4 161.5 159.6 161.6 226.6 401.6 
+     16384k: 162.0 162.8 164.7 162.8 162.0 162.9 227.0 402.9 
+
+##########################################################################
+
+Executing benchmark twice on cluster 0 (Cortex-A55)
+
+OpenSSL 1.1.1n, built on 15 Mar 2022
+type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
+aes-128-cbc     178585.53k   525309.46k  1019822.68k  1335233.88k  1466673.83k  1476307.63k
+aes-128-cbc     176625.41k   520911.79k  1014090.07k  1331962.54k  1466075.82k  1476635.31k
+aes-192-cbc     167738.79k   462053.03k   820737.96k  1022213.80k  1100890.11k  1106695.51k
+aes-192-cbc     169350.38k   463113.19k   823974.31k  1024407.55k  1103484.25k  1109174.95k
+aes-256-cbc     164534.59k   428173.23k   712321.02k   857102.34k   910568.11k   914462.04k
+aes-256-cbc     164518.40k   428048.96k   713099.78k   857376.77k   910939.48k   914210.82k
+
+##########################################################################
+
+Executing benchmark single-threaded on cpu0 (Cortex-A55)
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,64 bits,4 CPUs LE)
+
+LE
+CPU Freq: - - - - - - - - -
+
+RAM size:    3738 MB,  # CPU hardware threads:   4
+RAM usage:    435 MB,  # Benchmark threads:      1
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:       1066   100   1039   1038  |      22258   100   1902   1900
+23:       1032   100   1053   1052  |      21724   100   1882   1880
+24:       1020   100   1098   1097  |      21305   100   1872   1870
+25:       1011   100   1156   1155  |      20886   100   1860   1859
+----------------------------------  | ------------------------------
+Avr:             100   1086   1085  |              100   1879   1878
+Tot:             100   1482   1482
+
+##########################################################################
+
+Executing benchmark 3 times multi-threaded on CPUs 0-3
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,64 bits,4 CPUs LE)
+
+LE
+CPU Freq: - 64000000 64000000 - - - - - -
+
+RAM size:    3738 MB,  # CPU hardware threads:   4
+RAM usage:    882 MB,  # Benchmark threads:      4
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:       2876   339    826   2798  |      84234   397   1809   7187
+23:       2784   338    839   2837  |      81248   393   1789   7030
+24:       2749   335    884   2956  |      80495   397   1779   7066
+25:       2855   349    933   3260  |      77999   394   1762   6942
+----------------------------------  | ------------------------------
+Avr:             340    870   2963  |              395   1785   7056
+Tot:             368   1328   5010
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,64 bits,4 CPUs LE)
+
+LE
+CPU Freq: 64000000 - - - - - - - -
+
+RAM size:    3738 MB,  # CPU hardware threads:   4
+RAM usage:    882 MB,  # Benchmark threads:      4
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:       2927   343    831   2848  |      84349   398   1808   7196
+23:       2910   347    855   2965  |      82243   398   1788   7116
+24:       2772   336    886   2981  |      80874   399   1781   7100
+25:       2762   341    924   3155  |      79062   398   1770   7036
+----------------------------------  | ------------------------------
+Avr:             342    874   2987  |              398   1787   7112
+Tot:             370   1330   5050
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C,Utf16=off,HugeFiles=on,64 bits,4 CPUs LE)
+
+LE
+CPU Freq: 64000000 - - - - - - - -
+
+RAM size:    3738 MB,  # CPU hardware threads:   4
+RAM usage:    882 MB,  # Benchmark threads:      4
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:       2874   336    832   2796  |      84486   398   1810   7208
+23:       2841   342    847   2895  |      82326   398   1789   7123
+24:       2855   346    887   3071  |      79129   393   1767   6946
+25:       2833   349    928   3235  |      79095   398   1768   7039
+----------------------------------  | ------------------------------
+Avr:             343    873   2999  |              397   1784   7079
+Tot:             370   1328   5039
+
+Compression: 2963,2987,2999
+Decompression: 7056,7112,7079
+Total: 5010,5050,5039
+
+##########################################################################
+
+** cpuminer-multi 1.3.7 by tpruvot@github **
+BTC donation address: 1FhDPLPpw18X4srecguG3MxJYe4a1JsZnd (tpruvot)
+
+[2022-12-22 05:23:35] 4 miner threads started, using 'scrypt' algorithm.
+[2022-12-22 05:23:35] CPU #0: 1.60 kH/s
+[2022-12-22 05:23:35] CPU #2: 1.62 kH/s
+[2022-12-22 05:23:35] CPU #1: 1.61 kH/s
+[2022-12-22 05:23:35] CPU #3: 1.55 kH/s
+[2022-12-22 05:23:35] Total: 6.38 kH/s
+[2022-12-22 05:23:40] Total: 6.66 kH/s
+[2022-12-22 05:23:45] CPU #3: 1.84 kH/s
+[2022-12-22 05:23:45] Total: 7.28 kH/s
+[2022-12-22 05:23:45] CPU #0: 1.83 kH/s
+[2022-12-22 05:23:45] CPU #1: 1.84 kH/s
+[2022-12-22 05:23:45] CPU #2: 1.82 kH/s
+[2022-12-22 05:23:50] Total: 7.33 kH/s
+[2022-12-22 05:23:55] CPU #3: 1.84 kH/s
+[2022-12-22 05:23:55] Total: 7.34 kH/s
+[2022-12-22 05:23:55] CPU #0: 1.83 kH/s
+[2022-12-22 05:23:55] CPU #1: 1.84 kH/s
+[2022-12-22 05:23:55] CPU #2: 1.83 kH/s
+[2022-12-22 05:24:00] Total: 7.33 kH/s
+[2022-12-22 05:24:05] CPU #3: 1.84 kH/s
+[2022-12-22 05:24:05] Total: 7.33 kH/s
+[2022-12-22 05:24:05] CPU #0: 1.83 kH/s
+[2022-12-22 05:24:05] CPU #1: 1.83 kH/s
+[2022-12-22 05:24:05] CPU #2: 1.82 kH/s
+[2022-12-22 05:24:10] Total: 7.33 kH/s
+[2022-12-22 05:24:15] CPU #3: 1.84 kH/s
+[2022-12-22 05:24:15] Total: 7.33 kH/s
+[2022-12-22 05:24:15] CPU #0: 1.83 kH/s
+[2022-12-22 05:24:15] CPU #1: 1.84 kH/s
+[2022-12-22 05:24:15] CPU #2: 1.82 kH/s
+[2022-12-22 05:24:20] Total: 7.33 kH/s
+[2022-12-22 05:24:25] CPU #3: 1.82 kH/s
+[2022-12-22 05:24:25] Total: 7.32 kH/s
+[2022-12-22 05:24:25] CPU #0: 1.82 kH/s
+[2022-12-22 05:24:25] CPU #1: 1.82 kH/s
+[2022-12-22 05:24:25] CPU #2: 1.81 kH/s
+[2022-12-22 05:24:30] Total: 7.28 kH/s
+[2022-12-22 05:24:35] CPU #3: 1.84 kH/s
+[2022-12-22 05:24:35] Total: 7.33 kH/s
+[2022-12-22 05:24:35] CPU #0: 1.83 kH/s
+[2022-12-22 05:24:35] CPU #1: 1.84 kH/s
+[2022-12-22 05:24:35] CPU #2: 1.83 kH/s
+[2022-12-22 05:24:40] Total: 7.33 kH/s
+[2022-12-22 05:24:45] CPU #3: 1.84 kH/s
+[2022-12-22 05:24:45] Total: 7.33 kH/s
+[2022-12-22 05:24:45] CPU #0: 1.83 kH/s
+[2022-12-22 05:24:45] CPU #1: 1.83 kH/s
+[2022-12-22 05:24:45] CPU #2: 1.82 kH/s
+[2022-12-22 05:24:50] Total: 7.33 kH/s
+[2022-12-22 05:24:55] CPU #3: 1.84 kH/s
+[2022-12-22 05:24:55] Total: 7.33 kH/s
+[2022-12-22 05:24:55] CPU #0: 1.83 kH/s
+[2022-12-22 05:24:55] CPU #1: 1.83 kH/s
+[2022-12-22 05:24:55] CPU #2: 1.83 kH/s
+[2022-12-22 05:25:00] Total: 7.33 kH/s
+[2022-12-22 05:25:05] CPU #3: 1.84 kH/s
+[2022-12-22 05:25:05] Total: 7.33 kH/s
+[2022-12-22 05:25:05] CPU #0: 1.83 kH/s
+[2022-12-22 05:25:05] CPU #1: 1.83 kH/s
+[2022-12-22 05:25:05] CPU #2: 1.82 kH/s
+[2022-12-22 05:25:10] Total: 7.30 kH/s
+[2022-12-22 05:25:15] CPU #3: 1.84 kH/s
+[2022-12-22 05:25:15] Total: 7.29 kH/s
+[2022-12-22 05:25:15] CPU #0: 1.83 kH/s
+[2022-12-22 05:25:15] CPU #1: 1.84 kH/s
+[2022-12-22 05:25:15] CPU #2: 1.82 kH/s
+[2022-12-22 05:25:20] Total: 7.33 kH/s
+[2022-12-22 05:25:25] CPU #3: 1.84 kH/s
+[2022-12-22 05:25:25] Total: 7.33 kH/s
+[2022-12-22 05:25:25] CPU #0: 1.83 kH/s
+[2022-12-22 05:25:25] CPU #1: 1.84 kH/s
+[2022-12-22 05:25:25] CPU #2: 1.82 kH/s
+[2022-12-22 05:25:30] Total: 7.33 kH/s
+[2022-12-22 05:25:35] CPU #3: 1.84 kH/s
+[2022-12-22 05:25:35] Total: 7.33 kH/s
+[2022-12-22 05:25:35] CPU #0: 1.83 kH/s
+[2022-12-22 05:25:35] CPU #1: 1.83 kH/s
+[2022-12-22 05:25:35] CPU #2: 1.82 kH/s
+[2022-12-22 05:25:40] Total: 7.33 kH/s
+[2022-12-22 05:25:45] CPU #3: 1.84 kH/s
+[2022-12-22 05:25:45] Total: 7.33 kH/s
+[2022-12-22 05:25:45] CPU #0: 1.83 kH/s
+[2022-12-22 05:25:45] CPU #1: 1.83 kH/s
+[2022-12-22 05:25:45] CPU #2: 1.83 kH/s
+[2022-12-22 05:25:50] Total: 7.33 kH/s
+[2022-12-22 05:25:55] CPU #3: 1.82 kH/s
+[2022-12-22 05:25:55] Total: 7.31 kH/s
+[2022-12-22 05:25:55] CPU #0: 1.82 kH/s
+[2022-12-22 05:25:55] CPU #1: 1.82 kH/s
+[2022-12-22 05:25:55] CPU #2: 1.81 kH/s
+[2022-12-22 05:26:00] Total: 7.29 kH/s
+[2022-12-22 05:26:05] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:05] Total: 7.33 kH/s
+[2022-12-22 05:26:05] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:05] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:05] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:10] Total: 7.33 kH/s
+[2022-12-22 05:26:15] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:15] Total: 7.33 kH/s
+[2022-12-22 05:26:15] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:15] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:15] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:20] Total: 7.33 kH/s
+[2022-12-22 05:26:25] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:25] Total: 7.33 kH/s
+[2022-12-22 05:26:25] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:25] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:25] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:30] Total: 7.32 kH/s
+[2022-12-22 05:26:35] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:35] Total: 7.32 kH/s
+[2022-12-22 05:26:35] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:35] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:35] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:40] Total: 7.31 kH/s
+[2022-12-22 05:26:44] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:44] Total: 7.29 kH/s
+[2022-12-22 05:26:45] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:45] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:45] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:45] Total: 7.33 kH/s
+[2022-12-22 05:26:50] CPU #3: 1.84 kH/s
+[2022-12-22 05:26:50] Total: 7.33 kH/s
+[2022-12-22 05:26:55] CPU #0: 1.83 kH/s
+[2022-12-22 05:26:55] CPU #1: 1.83 kH/s
+[2022-12-22 05:26:55] CPU #2: 1.82 kH/s
+[2022-12-22 05:26:55] Total: 7.33 kH/s
+[2022-12-22 05:27:00] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:00] Total: 7.33 kH/s
+[2022-12-22 05:27:05] CPU #0: 1.83 kH/s
+[2022-12-22 05:27:05] CPU #1: 1.83 kH/s
+[2022-12-22 05:27:05] CPU #2: 1.82 kH/s
+[2022-12-22 05:27:05] Total: 7.33 kH/s
+[2022-12-22 05:27:10] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:10] Total: 7.33 kH/s
+[2022-12-22 05:27:15] CPU #0: 1.83 kH/s
+[2022-12-22 05:27:15] CPU #1: 1.83 kH/s
+[2022-12-22 05:27:15] CPU #2: 1.82 kH/s
+[2022-12-22 05:27:15] Total: 7.32 kH/s
+[2022-12-22 05:27:21] CPU #3: 1.83 kH/s
+[2022-12-22 05:27:21] Total: 7.32 kH/s
+[2022-12-22 05:27:25] Total: 7.31 kH/s
+[2022-12-22 05:27:25] CPU #1: 1.83 kH/s
+[2022-12-22 05:27:25] CPU #0: 1.81 kH/s
+[2022-12-22 05:27:25] CPU #2: 1.81 kH/s
+[2022-12-22 05:27:29] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:29] Total: 7.29 kH/s
+[2022-12-22 05:27:30] Total: 7.33 kH/s
+[2022-12-22 05:27:35] CPU #0: 1.83 kH/s
+[2022-12-22 05:27:35] CPU #1: 1.84 kH/s
+[2022-12-22 05:27:35] CPU #2: 1.82 kH/s
+[2022-12-22 05:27:35] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:35] Total: 7.33 kH/s
+[2022-12-22 05:27:40] Total: 7.33 kH/s
+[2022-12-22 05:27:45] CPU #0: 1.83 kH/s
+[2022-12-22 05:27:45] CPU #1: 1.83 kH/s
+[2022-12-22 05:27:45] CPU #2: 1.82 kH/s
+[2022-12-22 05:27:45] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:45] Total: 7.33 kH/s
+[2022-12-22 05:27:50] Total: 7.33 kH/s
+[2022-12-22 05:27:55] CPU #0: 1.83 kH/s
+[2022-12-22 05:27:55] CPU #1: 1.83 kH/s
+[2022-12-22 05:27:55] CPU #2: 1.82 kH/s
+[2022-12-22 05:27:55] CPU #3: 1.84 kH/s
+[2022-12-22 05:27:55] Total: 7.33 kH/s
+[2022-12-22 05:28:00] Total: 7.33 kH/s
+[2022-12-22 05:28:05] CPU #0: 1.83 kH/s
+[2022-12-22 05:28:05] CPU #1: 1.83 kH/s
+[2022-12-22 05:28:05] CPU #2: 1.82 kH/s
+[2022-12-22 05:28:05] CPU #3: 1.83 kH/s
+[2022-12-22 05:28:05] Total: 7.31 kH/s
+[2022-12-22 05:28:10] Total: 7.28 kH/s
+[2022-12-22 05:28:15] CPU #0: 1.83 kH/s
+[2022-12-22 05:28:15] CPU #1: 1.83 kH/s
+[2022-12-22 05:28:15] CPU #2: 1.82 kH/s
+[2022-12-22 05:28:15] CPU #3: 1.84 kH/s
+[2022-12-22 05:28:15] Total: 7.32 kH/s
+[2022-12-22 05:28:20] Total: 7.32 kH/s
+[2022-12-22 05:28:25] CPU #0: 1.83 kH/s
+[2022-12-22 05:28:25] CPU #1: 1.83 kH/s
+[2022-12-22 05:28:25] CPU #2: 1.82 kH/s
+[2022-12-22 05:28:25] CPU #3: 1.84 kH/s
+[2022-12-22 05:28:25] Total: 7.32 kH/s
+[2022-12-22 05:28:30] Total: 7.32 kH/s
+[2022-12-22 05:28:35] CPU #0: 1.83 kH/s
+[2022-12-22 05:28:35] CPU #1: 1.83 kH/s
+[2022-12-22 05:28:35] CPU #2: 1.82 kH/s
+
+Total Scores: 7.34,7.33,7.32,7.31,7.30,7.29,7.28,6.66,6.38
+
+##########################################################################
+
+Testing maximum cpufreq again, still under full load. System health now:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:28:08: 1992MHz  4.12 100%   0%  99%   0%   0%   0%  61.1°C
+
+Checking cpufreq OPP (Cortex-A55):
+
+Cpufreq OPP: 1992    Measured: 1954 (1955.015/1954.784/1954.784)     (-1.9%)
+
+##########################################################################
+
+Hardware sensors:
+
+gpu_thermal-virtual-0
+temp1:        +46.7 C  (crit = +95.0 C)
+
+cpu_thermal-virtual-0
+temp1:        +51.9 C  (crit = +95.0 C)
+
+##########################################################################
+
+Thermal source: /sys/devices/virtual/thermal/thermal_zone0/ (cpu-thermal)
+
+System health while running tinymembench:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:06:43: 1992MHz  1.46   0%   0%   0%   0%   0%   0%  45.0°C
+05:07:23: 1992MHz  1.46  25%   0%  25%   0%   0%   0%  46.7°C
+05:08:03: 1992MHz  1.23  25%   0%  25%   0%   0%   0%  46.7°C
+05:08:43: 1992MHz  1.12  25%   0%  25%   0%   0%   0%  46.1°C
+05:09:23: 1992MHz  1.27  25%   0%  25%   0%   0%   0%  45.6°C
+05:10:03: 1992MHz  1.14  25%   0%  25%   0%   0%   0%  45.6°C
+05:10:43: 1992MHz  1.07  25%   0%  25%   0%   0%   0%  45.6°C
+05:11:23: 1992MHz  1.16  25%   0%  25%   0%   0%   0%  45.6°C
+05:12:03: 1992MHz  1.08  25%   0%  25%   0%   0%   0%  46.1°C
+05:12:44: 1992MHz  1.04  25%   0%  25%   0%   0%   0%  45.6°C
+05:13:24: 1992MHz  1.20  25%   0%  25%   0%   0%   0%  45.6°C
+05:14:04: 1992MHz  1.10  25%   0%  25%   0%   0%   0%  45.6°C
+05:14:44: 1992MHz  1.05  25%   0%  25%   0%   0%   0%  45.0°C
+
+System health while running ramlat:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:15:13: 1992MHz  1.16   0%   0%   0%   0%   0%   0%  46.7°C
+05:15:16: 1992MHz  1.15  25%   0%  25%   0%   0%   0%  46.1°C
+05:15:19: 1992MHz  1.13  25%   0%  25%   0%   0%   0%  46.7°C
+05:15:22: 1992MHz  1.13  25%   0%  25%   0%   0%   0%  46.1°C
+05:15:25: 1992MHz  1.12  25%   0%  25%   0%   0%   0%  46.1°C
+05:15:28: 1992MHz  1.12  25%   0%  25%   0%   0%   0%  45.6°C
+05:15:32: 1992MHz  1.11  25%   0%  25%   0%   0%   0%  45.6°C
+05:15:35: 1992MHz  1.10  25%   0%  25%   0%   0%   0%  45.6°C
+05:15:38: 1992MHz  1.10  25%   0%  25%   0%   0%   0%  45.6°C
+
+System health while running OpenSSL benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:15:40: 1992MHz  1.10   0%   0%   0%   0%   0%   0%  46.1°C
+05:15:56: 1992MHz  1.07  25%   0%  25%   0%   0%   0%  45.6°C
+05:16:12: 1992MHz  1.06  25%   0%  25%   0%   0%   0%  45.6°C
+05:16:28: 1992MHz  1.04  25%   0%  25%   0%   0%   0%  47.8°C
+05:16:44: 1992MHz  1.03  25%   0%  25%   0%   0%   0%  45.6°C
+05:17:00: 1992MHz  1.18  25%   0%  25%   0%   0%   0%  45.6°C
+05:17:16: 1992MHz  1.14  25%   0%  25%   0%   0%   0%  46.1°C
+
+System health while running 7-zip single core benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:17:28: 1992MHz  1.12   0%   0%   0%   0%   0%   0%  47.2°C
+05:17:37: 1992MHz  1.10  25%   0%  25%   0%   0%   0%  46.7°C
+05:17:46: 1992MHz  1.08  25%   0%  25%   0%   0%   0%  47.8°C
+05:17:55: 1992MHz  1.07  25%   0%  24%   0%   0%   0%  46.1°C
+05:18:04: 1992MHz  1.06  25%   0%  24%   0%   0%   0%  47.8°C
+05:18:13: 1992MHz  1.13  25%   0%  24%   0%   0%   0%  46.7°C
+05:18:22: 1992MHz  1.11  25%   0%  24%   0%   0%   0%  47.2°C
+05:18:31: 1992MHz  1.09  25%   0%  24%   0%   0%   0%  47.2°C
+05:18:40: 1992MHz  1.08  25%   0%  24%   0%   0%   0%  46.7°C
+05:18:49: 1992MHz  1.22  25%   0%  24%   0%   0%   0%  46.7°C
+05:18:58: 1992MHz  1.20  25%   0%  24%   0%   0%   0%  46.7°C
+05:19:08: 1992MHz  1.24  25%   0%  24%   0%   0%   0%  47.8°C
+
+System health while running 7-zip multi core benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:19:12: 1992MHz  1.22   0%   0%   0%   0%   0%   0%  47.8°C
+05:19:31: 1992MHz  2.08  91%   0%  90%   0%   0%   0%  51.2°C
+05:19:50: 1992MHz  2.56  89%   0%  89%   0%   0%   0%  51.2°C
+05:20:09: 1992MHz  2.81  88%   0%  88%   0%   0%   0%  52.5°C
+05:20:28: 1992MHz  3.23  87%   1%  86%   0%   0%   0%  52.5°C
+05:20:47: 1992MHz  3.66  92%   0%  91%   0%   0%   0%  52.5°C
+05:21:10: 1992MHz  3.82  94%   0%  94%   0%   0%   0%  57.8°C
+05:21:34: 1992MHz  3.95  90%   0%  90%   0%   0%   0%  57.8°C
+05:21:54: 1992MHz  4.11  84%   0%  83%   0%   0%   0%  53.1°C
+05:22:13: 1992MHz  4.00  91%   0%  91%   0%   0%   0%  53.1°C
+05:22:36: 1992MHz  3.92  91%   0%  91%   0%   0%   0%  57.2°C
+05:23:00: 1992MHz  4.20  92%   0%  91%   0%   0%   0%  58.3°C
+05:23:19: 1992MHz  4.20  85%   0%  84%   0%   0%   0%  53.8°C
+
+System health while running cpuminer:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+05:23:39: 1992MHz  4.27   0%   0%   0%   0%   0%   0%  58.9°C
+05:24:24: 1992MHz  4.17 100%   0%  99%   0%   0%   0%  59.4°C
+05:25:09: 1992MHz  4.21 100%   0%  99%   0%   0%   0%  60.0°C
+05:25:54: 1992MHz  4.14 100%   0%  99%   0%   0%   0%  60.0°C
+05:26:39: 1992MHz  4.25 100%   0%  99%   0%   0%   0%  60.6°C
+05:27:23: 1992MHz  4.24 100%   0%  99%   0%   0%   0%  60.6°C
+05:28:08: 1992MHz  4.12 100%   0%  99%   0%   0%   0%  61.1°C
+
+##########################################################################
+
+Linux 6.1.0 (nanopir5s) 	12/22/22 	_aarch64_	(4 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.65    0.00    0.05    0.00    0.00   99.30
+
+Device             tps    kB_read/s    kB_wrtn/s    kB_dscd/s    kB_read    kB_wrtn    kB_dscd
+mmcblk1           0.13         2.27         1.74       106.52     280218     214733   13136992
+zram0             0.00         0.01         0.00         0.00       1304          4          0
+
+               total        used        free      shared  buff/cache   available
+Mem:           3.7Gi       160Mi       3.4Gi        14Mi        85Mi       3.4Gi
+Swap:          1.0Gi          0B       1.0Gi
+
+Filename				Type		Size	Used	Priority
+/dev/zram0                             	partition	1048572	0	100
+
+WARNING: ZSWAP ON TOP OF ZRAM HAS BEEN CONFIGURED ON THIS SYSTEM!
+THIS WILL SEVERELY HARM PERFORMANCE IN CASE SWAPPING OCCURS!
+
+Zswap active using lzo/zbud, max pool occupation: 20%, details:
+	duplicate_entry:0
+	pool_limit_hit:0
+	pool_total_size:0
+	reject_alloc_fail:0
+	reject_compress_poor:0
+	reject_kmemcache_fail:0
+	reject_reclaim_fail:0
+	same_filled_pages:0
+	stored_pages:0
+	written_back_pages:0
+
+CPU sysfs topology (clusters, cpufreq members, clockspeeds)
+                 cpufreq   min    max
+ CPU    cluster  policy   speed  speed   core type
+  0        0        0      408    1992   Cortex-A55 / r2p0
+  1        0        0      408    1992   Cortex-A55 / r2p0
+  2        0        0      408    1992   Cortex-A55 / r2p0
+  3        0        0      408    1992   Cortex-A55 / r2p0
+
+Architecture:                    aarch64
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Little Endian
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+Thread(s) per core:              1
+Core(s) per socket:              4
+Socket(s):                       1
+NUMA node(s):                    1
+Vendor ID:                       ARM
+Model:                           0
+Model name:                      Cortex-A55
+Stepping:                        r2p0
+CPU max MHz:                     1992.0000
+CPU min MHz:                     408.0000
+BogoMIPS:                        48.00
+NUMA node0 CPU(s):               0-3
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Not affected
+Vulnerability Mmio stale data:   Not affected
+Vulnerability Retbleed:          Not affected
+Vulnerability Spec store bypass: Not affected
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Not affected
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected
+Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
+
+SoC guess: Rockchip RK3568
+DT compat: friendlyelec,nanopi-r5s
+           rockchip,rk3568
+ Compiler: /usr/bin/gcc (Debian 10.2.1-6) 10.2.1 20210110 / aarch64-linux-gnu
+ Userland: arm64
+   Kernel: 6.1.0/aarch64
+           CONFIG_HZ=1000
+           CONFIG_HZ_1000=y
+           CONFIG_PREEMPT_NOTIFIERS=y
+           CONFIG_PREEMPT_VOLUNTARY=y
+           CONFIG_PREEMPT_VOLUNTARY_BUILD=y
+           raid6: neonx8   gen()  1375 MB/s
+           raid6: neonx4   gen()  1426 MB/s
+           raid6: neonx2   gen()  1289 MB/s
+           raid6: neonx1   gen()  1057 MB/s
+           raid6: int64x8  gen()   972 MB/s
+           raid6: int64x4  gen()  1045 MB/s
+           raid6: int64x2  gen()   944 MB/s
+           raid6: int64x1  gen()   643 MB/s
+           raid6: using algorithm neonx4 gen() 1426 MB/s
+           raid6: .... xor() 1089 MB/s, rmw enabled
+           raid6: using neon recovery algorithm
+           xor: measuring software checksum speed
+           xor: using function: 8regs (1712 MB/sec)
+
+##########################################################################
+
+   vcc_ddr: 500 mV (0 mV max)
+   vdd_cpu: 1150 mV (1150 mV max)
+   vdd_gpu: 825 mV (1350 mV max)
+   vdd_npu: 500 mV (1350 mV max)
+
+   opp-table-0:
+       408 MHz    900.0 mV
+       600 MHz    900.0 mV
+       816 MHz    900.0 mV
+      1104 MHz    900.0 mV
+      1416 MHz    900.0 mV
+      1608 MHz    975.0 mV
+      1800 MHz   1050.0 mV
+      1992 MHz   1150.0 mV
+
+   opp-table-1:
+       200 MHz    825.0 mV
+       300 MHz    825.0 mV
+       400 MHz    825.0 mV
+       600 MHz    825.0 mV
+       700 MHz    900.0 mV
+       800 MHz   1000.0 mV
+
+| FriendlyElec NanoPi R5S | 1992 MHz | 6.1 | Debian GNU/Linux 11 (bullseye) arm64 | 5030 | 1482 | 914340 | 2990 | 5970 | 7.33 |


### PR DESCRIPTION
Image used was built with https://github.com/pyavitz/debian-image-builder as device is not currently supported by Armbian.