### PR TITLE
Add NVIDIA Orin Nano Developer Kit

### DIFF
--- a/Results.md
+++ b/Results.md
@@ -39,6 +39,7 @@ So do **not** rely on collected numbers unless you carefully read through all th
 | [Jetson AGX Orin](http://ix.io/4ax9) | 2200 MHz | 5.10 | Focal arm64 | 39450 | 3187 | 1242940 | 10600 | 30350 | 59.96 |
 | [Jetson Nano](http://ix.io/4rLX) | 1480 MHz | 4.9 | Bullseye arm64 | 5260 | 1578 | 531940 | 3730 | 8870 | - |
 | [Jetson Nano](http://ix.io/3Ufc) | 2000 MHz | 4.9 | Bionic arm64 | 6260 | 1977 | 717500 | 4100 | 11760 | 8.72 |
+| [Jetson Orin Nano](http://ix.io/4vgu) | 1510 MHz | 5.10 | Focal arm64 | 13190 | 2136 | 853580 | 6740 | 20240 | 20.60 |
 | [Jetson Xavier AGX](http://ix.io/4ebH) | 2250 MHz | 4.9 | Bionic arm64 | 21590 | 2742 | 853250 | 10910 | 22520 | 26.57 |
 | [Jetson Xavier NX](http://ix.io/3YWp) | 1890 MHz | 4.9 | Bionic arm64 | 13230 | 2201 | 706280 | 9190 | 18480 | - |
 | [Kendryte K510](http://ix.io/41Qa) | 790 MHz | 4.17 | Sid riscv64 | 690 | 402 | 7410 | 280 | 440 | - |

--- a/results/4vgu.txt
+++ b/results/4vgu.txt
@@ -1,0 +1,882 @@
+sbc-bench v0.9.41 NVIDIA Orin Nano Developer Kit (Fri, 05 May 2023 20:59:12 +0200)
+
+Distributor ID:	Ubuntu
+Description:	Ubuntu 20.04.6 LTS
+Release:	20.04
+Codename:	focal
+
+Device Info:
+	Manufacturer: Unknown
+	Product Name: NVIDIA Orin NX Developer Kit
+	SKU Number: Unknown
+	Family: Unknown
+
+BIOS/UEFI:
+	Vendor: EDK II
+	Version: 3.0-32616947
+	Release Date: 02/21/2023
+
+/usr/bin/gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
+
+Uptime: 20:59:13 up 1 day, 49 min,  3 users,  load average: 1.50, 0.69, 0.42,  46.2°C,  92665610
+
+Linux 5.10.104-tegra (cale) 	05.05.2023 	_aarch64_	(6 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          13.37    0.36    9.73    0.60    0.00   75.93
+
+Device             tps    kB_read/s    kB_wrtn/s    kB_dscd/s    kB_read    kB_wrtn    kB_dscd
+mmcblk1           1.33        33.62       121.71        14.82    3004665   10876336    1324604
+nvme0n1           0.00         0.12         0.00         0.00      11080          0          0
+zram0             0.05         0.04         0.17         0.00       3548      15620          0
+zram1             0.05         0.04         0.17         0.00       3628      15536          0
+zram2             0.05         0.04         0.17         0.00       3532      15596          0
+zram3             0.05         0.04         0.17         0.00       3724      15056          0
+zram4             0.05         0.04         0.17         0.00       3892      15256          0
+zram5             0.05         0.04         0.17         0.00       3944      15364          0
+
+              total        used        free      shared  buff/cache   available
+Mem:          6.3Gi       2.5Gi       3.3Gi        45Mi       579Mi       3.6Gi
+Swap:         3.2Gi        82Mi       3.1Gi
+
+Filename				Type		Size	Used	Priority
+/dev/zram0                             	partition	553008	14368	5
+/dev/zram1                             	partition	553008	14284	5
+/dev/zram2                             	partition	553008	14408	5
+/dev/zram3                             	partition	553008	13892	5
+/dev/zram4                             	partition	553008	13716	5
+/dev/zram5                             	partition	553008	13776	5
+
+##########################################################################
+
+Checking cpufreq OPP (Cortex-A78AE):
+
+Cpufreq OPP: 1510    Measured: 1509 (1510.556/1508.729/1508.729)
+Cpufreq OPP: 1497    Measured: 1495 (1497.452/1496.029/1492.348)
+Cpufreq OPP: 1420    Measured: 1419 (1419.517/1419.517/1418.208)
+Cpufreq OPP: 1344    Measured: 1342 (1342.825/1342.689/1342.662)
+Cpufreq OPP: 1267    Measured: 1266 (1268.192/1265.945/1265.915)
+Cpufreq OPP: 1190    Measured: 1189 (1189.154/1189.074/1188.833)
+Cpufreq OPP: 1113    Measured: 1112 (1114.179/1112.118/1111.206)
+Cpufreq OPP: 1036    Measured: 1035 (1035.763/1035.535/1035.535)
+Cpufreq OPP:  960    Measured:  958    (958.935/958.848/958.848)
+Cpufreq OPP:  883    Measured:  881    (882.091/881.999/881.888)
+Cpufreq OPP:  806    Measured:  803    (805.310/804.812/801.800)
+Cpufreq OPP:  729    Measured:  728    (728.545/728.467/728.247)
+Cpufreq OPP:  652    Measured:  651    (651.676/651.645/651.613)
+Cpufreq OPP:  576    Measured:  574    (574.894/574.870/574.870)
+Cpufreq OPP:  499    Measured:  498    (498.227/498.135/498.021)
+Cpufreq OPP:  422    Measured:  421    (421.417/421.335/421.314)
+Cpufreq OPP:  345    Measured:  344    (344.696/344.576/344.542)
+Cpufreq OPP:  268    Measured:  267    (267.906/267.868/267.842)
+Cpufreq OPP:  192    Measured:  190    (191.192/191.188/190.405)
+Cpufreq OPP:  115    Measured:  114    (114.426/114.391/114.308)
+
+##########################################################################
+
+Hardware sensors:
+
+ina3221-i2c-1-40
+VDD_IN:                  4.99 V  
+VDD_CPU_GPU_CV:          4.99 V  
+VDD_SOC:                 4.99 V  
+in4:                     4.84 V  
+in5:                   680.00 mV 
+in6:                     1.44 V  
+sum of shunt voltages:   7.16 V  
+curr1:                 968.00 mA (max =  +3.00 A, crit max =  +4.00 A)
+curr2:                 136.00 mA (max = +32.76 A, crit max = +32.76 A)
+curr3:                 288.00 mA (max = +32.76 A, crit max = +32.76 A)
+curr4:                   1.41 A  (crit max = +131.06 A)
+
+##########################################################################
+
+Executing benchmark on cpu0 (Cortex-A78AE):
+
+tinymembench v0.4.9-nuumio (simple benchmark for memory throughput and latency)
+
+CFLAGS: 
+bandwidth test min repeats (-b): 2
+bandwidth test max repeats (-B): 3
+bandwidth test mem realloc (-M): no      (-m for realloc)
+      latency test repeats (-l): 3
+        latency test count (-c): 1000000
+
+==========================================================================
+== Memory bandwidth tests                                               ==
+==                                                                      ==
+== Note 1: 1MB = 1000000 bytes                                          ==
+== Note 2: Test result is the best of repeated runs. Number of repeats  ==
+==         is shown in brackets                                         ==
+== Note 3: Results for 'copy' tests show how many bytes can be          ==
+==         copied per second (adding together read and writen           ==
+==         bytes would have provided twice higher numbers)              ==
+== Note 4: 2-pass copy means that we are using a small temporary buffer ==
+==         to first fetch data into it, and only then write it to the   ==
+==         destination (source -> L1 cache, L1 cache -> destination)    ==
+== Note 5: If sample standard deviation exceeds 0.1%, it is shown in    ==
+==         brackets                                                     ==
+==========================================================================
+
+ C copy backwards                                 :   6674.3 MB/s (3, 11.0%)
+ C copy backwards (32 byte blocks)                :   6693.4 MB/s (3, 0.1%)
+ C copy backwards (64 byte blocks)                :   6680.1 MB/s (3, 0.7%)
+ C copy                                           :   6731.3 MB/s (2)
+ C copy prefetched (32 bytes step)                :   6729.2 MB/s (2)
+ C copy prefetched (64 bytes step)                :   6714.6 MB/s (2)
+ C 2-pass copy                                    :   6428.0 MB/s (3, 0.8%)
+ C 2-pass copy prefetched (32 bytes step)         :   6457.9 MB/s (3, 0.2%)
+ C 2-pass copy prefetched (64 bytes step)         :   6435.9 MB/s (3, 0.5%)
+ C scan 8                                         :   1502.8 MB/s (2)
+ C scan 16                                        :   3009.1 MB/s (2)
+ C scan 32                                        :   5997.5 MB/s (2)
+ C scan 64                                        :   9532.1 MB/s (3, 0.8%)
+ C fill                                           :  20150.5 MB/s (3, 0.2%)
+ C fill (shuffle within 16 byte blocks)           :  20155.5 MB/s (2)
+ C fill (shuffle within 32 byte blocks)           :  20157.4 MB/s (3, 0.2%)
+ C fill (shuffle within 64 byte blocks)           :  20100.0 MB/s (3, 0.2%)
+ ---
+ libc memcpy copy                                 :   6739.2 MB/s (3, 0.4%)
+ libc memchr scan                                 :   9718.5 MB/s (3, 0.9%)
+ libc memset fill                                 :  20238.9 MB/s (3, 0.3%)
+ ---
+ NEON LDP/STP copy                                :   6757.0 MB/s (2)
+ NEON LDP/STP copy pldl2strm (32 bytes step)      :   6767.9 MB/s (3, 0.2%)
+ NEON LDP/STP copy pldl2strm (64 bytes step)      :   6785.8 MB/s (3, 0.5%)
+ NEON LDP/STP copy pldl1keep (32 bytes step)      :   6891.5 MB/s (3, 0.5%)
+ NEON LDP/STP copy pldl1keep (64 bytes step)      :   6977.2 MB/s (3, 0.7%)
+ NEON LD1/ST1 copy                                :   6764.1 MB/s (3, 0.2%)
+ NEON LDP load                                    :   9774.4 MB/s (3, 0.5%)
+ NEON LDNP load                                   :   9571.6 MB/s (3, 0.6%)
+ NEON STP fill                                    :  20116.5 MB/s (2)
+ NEON STNP fill                                   :  20188.5 MB/s (2)
+ ARM LDP/STP copy                                 :   6722.8 MB/s (2)
+ ARM LDP load                                     :   9592.9 MB/s (3, 0.6%)
+ ARM LDNP load                                    :   9590.7 MB/s (3, 0.3%)
+ ARM STP fill                                     :  20197.0 MB/s (3, 0.2%)
+ ARM STNP fill                                    :  20173.7 MB/s (2)
+
+==========================================================================
+== Framebuffer read tests.                                              ==
+==                                                                      ==
+== Many ARM devices use a part of the system memory as the framebuffer, ==
+== typically mapped as uncached but with write-combining enabled.       ==
+== Writes to such framebuffers are quite fast, but reads are much       ==
+== slower and very sensitive to the alignment and the selection of      ==
+== CPU instructions which are used for accessing memory.                ==
+==                                                                      ==
+== Many x86 systems allocate the framebuffer in the GPU memory,         ==
+== accessible for the CPU via a relatively slow PCI-E bus. Moreover,    ==
+== PCI-E is asymmetric and handles reads a lot worse than writes.       ==
+==                                                                      ==
+== If uncached framebuffer reads are reasonably fast (at least 100 MB/s ==
+== or preferably >300 MB/s), then using the shadow framebuffer layer    ==
+== is not necessary in Xorg DDX drivers, resulting in a nice overall    ==
+== performance improvement. For example, the xf86-video-fbturbo DDX     ==
+== uses this trick.                                                     ==
+==========================================================================
+
+ NEON LDP/STP copy (from framebuffer)             :    783.3 MB/s (3)
+ NEON LDP/STP 2-pass copy (from framebuffer)      :    755.5 MB/s (2)
+ NEON LD1/ST1 copy (from framebuffer)             :    782.8 MB/s (2)
+ NEON LD1/ST1 2-pass copy (from framebuffer)      :    750.8 MB/s (3)
+ ARM LDP/STP copy (from framebuffer)              :    782.9 MB/s (3, 0.2%)
+ ARM LDP/STP 2-pass copy (from framebuffer)       :    731.8 MB/s (2)
+
+==========================================================================
+== Memory latency test                                                  ==
+==                                                                      ==
+== Average time is measured for random memory accesses in the buffers   ==
+== of different sizes. The larger is the buffer, the more significant   ==
+== are relative contributions of TLB, L1/L2 cache misses and SDRAM      ==
+== accesses. For extremely large buffer sizes we are expecting to see   ==
+== page table walk with several requests to SDRAM for almost every      ==
+== memory access (though 64MiB is not nearly large enough to experience ==
+== this effect to its fullest).                                         ==
+==                                                                      ==
+== Note 1: All the numbers are representing extra time, which needs to  ==
+==         be added to L1 cache latency. The cycle timings for L1 cache ==
+==         latency can be usually found in the processor documentation. ==
+== Note 2: Dual random read means that we are simultaneously performing ==
+==         two independent memory accesses at a time. In the case if    ==
+==         the memory subsystem can't handle multiple outstanding       ==
+==         requests, dual random read has the same timings as two       ==
+==         single reads performed one after another.                    ==
+==========================================================================
+
+block size : single random read / dual random read, [MADV_NOHUGEPAGE]
+      1024 :    0.0 ns          /     0.0 ns 
+      2048 :    0.0 ns          /     0.0 ns 
+      4096 :    0.0 ns          /     0.0 ns 
+      8192 :    0.0 ns          /     0.0 ns 
+     16384 :    0.0 ns          /     0.0 ns 
+     32768 :    0.0 ns          /     0.0 ns 
+     65536 :    0.0 ns          /     0.0 ns 
+    131072 :    1.8 ns          /     2.5 ns 
+    262144 :    6.4 ns          /     8.3 ns 
+    524288 :   16.3 ns          /    20.6 ns 
+   1048576 :   24.9 ns          /    24.8 ns 
+   2097152 :   37.6 ns          /    32.6 ns 
+   4194304 :   66.7 ns          /    64.6 ns 
+   8388608 :  153.0 ns          /   183.2 ns 
+  16777216 :  226.1 ns          /   276.5 ns 
+  33554432 :  266.9 ns          /   304.5 ns 
+  67108864 :  287.5 ns          /   316.9 ns 
+
+block size : single random read / dual random read, [MADV_HUGEPAGE]
+      1024 :    0.0 ns          /     0.0 ns 
+      2048 :    0.0 ns          /     0.0 ns 
+      4096 :    0.0 ns          /     0.0 ns 
+      8192 :    0.0 ns          /     0.0 ns 
+     16384 :    0.0 ns          /     0.0 ns 
+     32768 :    0.0 ns          /     0.0 ns 
+     65536 :    0.0 ns          /     0.0 ns 
+    131072 :    1.7 ns          /     2.3 ns 
+    262144 :    3.1 ns          /     3.2 ns 
+    524288 :   13.9 ns          /    18.2 ns 
+   1048576 :   20.5 ns          /    21.9 ns 
+   2097152 :   29.2 ns          /    23.0 ns 
+   4194304 :   54.7 ns          /    58.3 ns 
+   8388608 :  143.4 ns          /   174.1 ns 
+  16777216 :  207.0 ns          /   264.2 ns 
+  33554432 :  248.1 ns          /   289.5 ns 
+  67108864 :  269.9 ns          /   297.2 ns 
+
+##########################################################################
+
+Executing ramlat on cpu0 (Cortex-A78AE), results in ns:
+
+       size:  1x32  2x32  1x64  2x64 1xPTR 2xPTR 4xPTR 8xPTR
+         4k: 2.660 2.663 2.659 2.655 2.655 2.653 2.654 5.135 
+         8k: 2.652 2.652 2.652 2.652 2.655 2.652 2.656 5.168 
+        16k: 2.653 2.652 2.652 2.659 2.656 2.656 2.656 5.160 
+        32k: 2.661 2.663 2.678 2.656 2.653 2.653 2.671 5.163 
+        64k: 2.659 2.658 2.655 2.654 2.654 2.655 2.662 5.161 
+       128k: 7.963 8.019 7.961 8.011 7.962 8.005 10.22 20.06 
+       256k: 8.069 8.119 8.078 8.119 8.065 8.473 10.53 20.39 
+       512k: 9.228 10.79 9.204 10.76 9.197 16.46 19.85 27.59 
+      1024k: 9.606 11.33 9.605 11.33 9.603 19.60 28.60 44.18 
+      2048k: 10.49 12.04 10.37 11.84 10.45 22.00 32.55 53.90 
+      4096k: 27.18 26.29 26.60 26.80 26.54 39.64 46.45 85.08 
+      8192k: 114.2 77.38 99.36 77.92 96.24 118.9 73.31 106.9 
+     16384k: 208.6 165.2 202.9 169.0 200.9 202.8 137.4 155.0 
+     32768k: 257.1 233.3 256.0 235.1 256.5 246.9 209.7 177.0 
+     65536k: 289.9 282.2 288.2 284.1 287.4 278.1 235.1 201.0 
+    131072k: 297.4 298.3 297.6 296.1 296.9 292.7 253.7 238.3 
+
+##########################################################################
+
+Executing benchmark twice on cluster 0 (Cortex-A78AE)
+
+OpenSSL 1.1.1f, built on 31 Mar 2020
+type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
+aes-128-cbc     655879.42k  1057463.68k  1154218.84k  1184039.25k  1196447.06k  1197473.79k
+aes-128-cbc     653433.18k  1055583.57k  1154068.14k  1183534.76k  1195201.88k  1196386.99k
+aes-192-cbc     607384.65k   900824.41k   970013.44k   987597.82k   992397.99k   993105.24k
+aes-192-cbc     607496.37k   899706.37k   969954.65k   986645.16k   991816.36k   991515.99k
+aes-256-cbc     587380.52k   777766.63k   833574.49k   848710.31k   852557.82k   853557.25k
+aes-256-cbc     591760.12k   778739.71k   833059.41k   848529.07k   852634.28k   853600.94k
+
+##########################################################################
+
+Executing benchmark single-threaded on cpu0 (Cortex-A78AE)
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C.UTF-8,Utf16=on,HugeFiles=on,64 bits,6 CPUs LE)
+
+LE
+CPU Freq: - - - - - - - - -
+
+RAM size:    6480 MB,  # CPU hardware threads:   6
+RAM usage:    435 MB,  # Benchmark threads:      1
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:       2024   100   1977   1969  |      27955   100   2395   2387
+23:       1871   100   1914   1907  |      27431   100   2382   2375
+24:       1770   100   1910   1903  |      26616   100   2345   2337
+25:       1668   100   1912   1905  |      25870   100   2311   2303
+----------------------------------  | ------------------------------
+Avr:             100   1928   1921  |              100   2358   2350
+Tot:             100   2143   2136
+
+##########################################################################
+
+Executing benchmark 3 times multi-threaded on CPUs 0-5
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C.UTF-8,Utf16=on,HugeFiles=on,64 bits,6 CPUs LE)
+
+LE
+CPU Freq: - - - - - - - - -
+
+RAM size:    6480 MB,  # CPU hardware threads:   6
+RAM usage:   1323 MB,  # Benchmark threads:      6
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:      13621   559   2373  13251  |     157894   580   2322  13465
+23:      13080   566   2356  13328  |     152609   578   2285  13205
+24:      12105   562   2317  13016  |     149533   584   2248  13125
+25:      11040   554   2275  12606  |     143218   582   2189  12746
+----------------------------------  | ------------------------------
+Avr:             560   2330  13050  |              581   2261  13135
+Tot:             571   2296  13093
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C.UTF-8,Utf16=on,HugeFiles=on,64 bits,6 CPUs LE)
+
+LE
+CPU Freq: - - - - 128000000 - - - -
+
+RAM size:    6480 MB,  # CPU hardware threads:   6
+RAM usage:   1323 MB,  # Benchmark threads:      6
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:      14316   576   2417  13927  |     160354   590   2320  13675
+23:      13272   565   2395  13523  |     154693   586   2284  13386
+24:      11772   549   2307  12658  |     151782   592   2249  13322
+25:      10848   544   2276  12387  |     143636   582   2197  12783
+----------------------------------  | ------------------------------
+Avr:             558   2349  13124  |              587   2262  13291
+Tot:             573   2306  13208
+
+7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
+p7zip Version 16.02 (locale=C.UTF-8,Utf16=on,HugeFiles=on,64 bits,6 CPUs LE)
+
+LE
+CPU Freq: 64000000 - - - - - - - -
+
+RAM size:    6480 MB,  # CPU hardware threads:   6
+RAM usage:   1323 MB,  # Benchmark threads:      6
+
+                       Compressing  |                  Decompressing
+Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
+         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS
+
+22:      14154   570   2415  13770  |     159768   586   2327  13625
+23:      13015   558   2378  13261  |     156626   592   2291  13553
+24:      12037   552   2343  12943  |     152015   592   2254  13343
+25:      11094   553   2289  12667  |     146093   592   2196  13002
+----------------------------------  | ------------------------------
+Avr:             558   2356  13160  |              590   2267  13381
+Tot:             574   2312  13270
+
+Compression: 13050,13124,13160
+Decompression: 13135,13291,13381
+Total: 13093,13208,13270
+
+##########################################################################
+
+** cpuminer-multi 1.3.7 by tpruvot@github **
+BTC donation address: 1FhDPLPpw18X4srecguG3MxJYe4a1JsZnd (tpruvot)
+
+[2023-05-05 21:07:58] 6 miner threads started, using 'scrypt' algorithm.
+[2023-05-05 21:07:58] CPU #0: 3.39 kH/s
+[2023-05-05 21:07:58] CPU #5: 3.42 kH/s
+[2023-05-05 21:07:58] CPU #2: 3.23 kH/s
+[2023-05-05 21:07:58] CPU #1: 3.19 kH/s
+[2023-05-05 21:07:58] CPU #3: 3.42 kH/s
+[2023-05-05 21:07:58] CPU #4: 3.15 kH/s
+[2023-05-05 21:08:03] Total: 20.35 kH/s
+[2023-05-05 21:08:08] CPU #1: 3.44 kH/s
+[2023-05-05 21:08:08] CPU #2: 3.43 kH/s
+[2023-05-05 21:08:08] CPU #4: 3.35 kH/s
+[2023-05-05 21:08:08] CPU #5: 3.44 kH/s
+[2023-05-05 21:08:08] Total: 20.33 kH/s
+[2023-05-05 21:08:08] CPU #3: 3.44 kH/s
+[2023-05-05 21:08:08] CPU #0: 3.34 kH/s
+[2023-05-05 21:08:13] Total: 20.50 kH/s
+[2023-05-05 21:08:18] CPU #2: 3.43 kH/s
+[2023-05-05 21:08:18] CPU #4: 3.35 kH/s
+[2023-05-05 21:08:18] CPU #1: 3.35 kH/s
+[2023-05-05 21:08:18] CPU #0: 3.42 kH/s
+[2023-05-05 21:08:18] CPU #3: 3.44 kH/s
+[2023-05-05 21:08:18] CPU #5: 3.43 kH/s
+[2023-05-05 21:08:18] Total: 20.43 kH/s
+[2023-05-05 21:08:23] Total: 20.58 kH/s
+[2023-05-05 21:08:28] CPU #4: 3.44 kH/s
+[2023-05-05 21:08:28] CPU #1: 3.44 kH/s
+[2023-05-05 21:08:28] CPU #2: 3.43 kH/s
+[2023-05-05 21:08:28] CPU #0: 3.42 kH/s
+[2023-05-05 21:08:28] CPU #3: 3.44 kH/s
+[2023-05-05 21:08:28] CPU #5: 3.43 kH/s
+[2023-05-05 21:08:28] Total: 20.59 kH/s
+[2023-05-05 21:08:33] Total: 20.48 kH/s
+[2023-05-05 21:08:37] CPU #5: 3.43 kH/s
+[2023-05-05 21:08:37] Total: 20.56 kH/s
+[2023-05-05 21:08:38] CPU #4: 3.43 kH/s
+[2023-05-05 21:08:38] CPU #1: 3.42 kH/s
+[2023-05-05 21:08:38] CPU #2: 3.43 kH/s
+[2023-05-05 21:08:38] CPU #0: 3.41 kH/s
+[2023-05-05 21:08:38] CPU #3: 3.44 kH/s
+[2023-05-05 21:08:38] Total: 20.53 kH/s
+[2023-05-05 21:08:43] CPU #5: 3.32 kH/s
+[2023-05-05 21:08:43] Total: 20.47 kH/s
+[2023-05-05 21:08:48] Total: 20.57 kH/s
+[2023-05-05 21:08:48] CPU #4: 3.43 kH/s
+[2023-05-05 21:08:48] CPU #1: 3.42 kH/s
+[2023-05-05 21:08:48] CPU #2: 3.34 kH/s
+[2023-05-05 21:08:48] CPU #0: 3.41 kH/s
+[2023-05-05 21:08:48] CPU #3: 3.44 kH/s
+[2023-05-05 21:08:53] CPU #5: 3.43 kH/s
+[2023-05-05 21:08:53] Total: 20.46 kH/s
+[2023-05-05 21:08:58] Total: 20.48 kH/s
+[2023-05-05 21:08:58] CPU #4: 3.44 kH/s
+[2023-05-05 21:08:58] CPU #1: 3.44 kH/s
+[2023-05-05 21:08:58] CPU #2: 3.34 kH/s
+[2023-05-05 21:08:58] CPU #0: 3.42 kH/s
+[2023-05-05 21:08:58] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:03] CPU #5: 3.43 kH/s
+[2023-05-05 21:09:03] Total: 20.50 kH/s
+[2023-05-05 21:09:08] CPU #4: 3.44 kH/s
+[2023-05-05 21:09:08] CPU #1: 3.44 kH/s
+[2023-05-05 21:09:08] CPU #2: 3.43 kH/s
+[2023-05-05 21:09:08] Total: 20.48 kH/s
+[2023-05-05 21:09:08] CPU #0: 3.43 kH/s
+[2023-05-05 21:09:08] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:13] CPU #5: 3.26 kH/s
+[2023-05-05 21:09:13] Total: 20.28 kH/s
+[2023-05-05 21:09:18] CPU #1: 3.44 kH/s
+[2023-05-05 21:09:18] CPU #4: 3.44 kH/s
+[2023-05-05 21:09:18] CPU #2: 3.43 kH/s
+[2023-05-05 21:09:18] Total: 20.42 kH/s
+[2023-05-05 21:09:18] CPU #0: 3.39 kH/s
+[2023-05-05 21:09:18] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:23] CPU #5: 3.43 kH/s
+[2023-05-05 21:09:23] Total: 20.57 kH/s
+[2023-05-05 21:09:28] Total: 20.39 kH/s
+[2023-05-05 21:09:28] CPU #4: 3.43 kH/s
+[2023-05-05 21:09:28] CPU #1: 3.35 kH/s
+[2023-05-05 21:09:28] CPU #2: 3.34 kH/s
+[2023-05-05 21:09:28] CPU #0: 3.42 kH/s
+[2023-05-05 21:09:28] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:33] CPU #5: 3.42 kH/s
+[2023-05-05 21:09:33] Total: 20.40 kH/s
+[2023-05-05 21:09:38] Total: 20.46 kH/s
+[2023-05-05 21:09:38] CPU #4: 3.44 kH/s
+[2023-05-05 21:09:38] CPU #1: 3.44 kH/s
+[2023-05-05 21:09:38] CPU #2: 3.43 kH/s
+[2023-05-05 21:09:38] CPU #0: 3.34 kH/s
+[2023-05-05 21:09:38] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:43] CPU #5: 3.43 kH/s
+[2023-05-05 21:09:43] Total: 20.48 kH/s
+[2023-05-05 21:09:48] CPU #4: 3.44 kH/s
+[2023-05-05 21:09:48] CPU #1: 3.44 kH/s
+[2023-05-05 21:09:48] CPU #2: 3.43 kH/s
+[2023-05-05 21:09:48] Total: 20.59 kH/s
+[2023-05-05 21:09:48] CPU #0: 3.43 kH/s
+[2023-05-05 21:09:48] CPU #3: 3.44 kH/s
+[2023-05-05 21:09:53] CPU #5: 3.43 kH/s
+[2023-05-05 21:09:53] Total: 20.59 kH/s
+[2023-05-05 21:09:58] CPU #1: 3.44 kH/s
+[2023-05-05 21:09:58] CPU #2: 3.43 kH/s
+[2023-05-05 21:09:58] CPU #4: 3.44 kH/s
+[2023-05-05 21:09:58] CPU #0: 3.42 kH/s
+[2023-05-05 21:09:58] Total: 20.50 kH/s
+[2023-05-05 21:09:58] CPU #3: 3.44 kH/s
+[2023-05-05 21:10:03] CPU #5: 3.43 kH/s
+[2023-05-05 21:10:03] Total: 20.59 kH/s
+[2023-05-05 21:10:08] CPU #4: 3.44 kH/s
+[2023-05-05 21:10:08] CPU #2: 3.43 kH/s
+[2023-05-05 21:10:08] CPU #1: 3.42 kH/s
+[2023-05-05 21:10:08] CPU #0: 3.42 kH/s
+[2023-05-05 21:10:08] Total: 20.55 kH/s
+[2023-05-05 21:10:08] CPU #3: 3.44 kH/s
+[2023-05-05 21:10:13] CPU #5: 3.43 kH/s
+[2023-05-05 21:10:13] Total: 20.57 kH/s
+[2023-05-05 21:10:18] CPU #4: 3.44 kH/s
+[2023-05-05 21:10:18] CPU #2: 3.43 kH/s
+[2023-05-05 21:10:18] CPU #1: 3.44 kH/s
+[2023-05-05 21:10:18] CPU #0: 3.42 kH/s
+[2023-05-05 21:10:18] CPU #3: 3.43 kH/s
+[2023-05-05 21:10:18] Total: 20.59 kH/s
+[2023-05-05 21:10:23] CPU #5: 3.43 kH/s
+[2023-05-05 21:10:24] Total: 20.58 kH/s
+[2023-05-05 21:10:28] Total: 20.59 kH/s
+[2023-05-05 21:10:28] CPU #2: 3.43 kH/s
+[2023-05-05 21:10:28] CPU #1: 3.44 kH/s
+[2023-05-05 21:10:28] CPU #4: 3.43 kH/s
+[2023-05-05 21:10:28] CPU #3: 3.43 kH/s
+[2023-05-05 21:10:28] CPU #0: 3.42 kH/s
+[2023-05-05 21:10:33] CPU #5: 3.35 kH/s
+[2023-05-05 21:10:33] Total: 20.50 kH/s
+[2023-05-05 21:10:38] Total: 20.61 kH/s
+[2023-05-05 21:10:38] CPU #4: 3.44 kH/s
+[2023-05-05 21:10:38] CPU #1: 3.44 kH/s
+[2023-05-05 21:10:38] CPU #2: 3.42 kH/s
+[2023-05-05 21:10:38] CPU #3: 3.43 kH/s
+[2023-05-05 21:10:39] CPU #0: 3.33 kH/s
+[2023-05-05 21:10:43] CPU #5: 3.44 kH/s
+[2023-05-05 21:10:43] Total: 20.59 kH/s
+[2023-05-05 21:10:48] Total: 20.49 kH/s
+[2023-05-05 21:10:48] CPU #1: 3.44 kH/s
+[2023-05-05 21:10:48] CPU #2: 3.42 kH/s
+[2023-05-05 21:10:48] CPU #4: 3.44 kH/s
+[2023-05-05 21:10:48] CPU #3: 3.43 kH/s
+[2023-05-05 21:10:49] CPU #0: 3.34 kH/s
+[2023-05-05 21:10:53] CPU #5: 3.44 kH/s
+[2023-05-05 21:10:53] Total: 20.61 kH/s
+[2023-05-05 21:10:57] CPU #0: 3.43 kH/s
+[2023-05-05 21:10:58] CPU #3: 3.42 kH/s
+[2023-05-05 21:10:58] Total: 20.59 kH/s
+[2023-05-05 21:10:58] CPU #1: 3.43 kH/s
+[2023-05-05 21:10:58] CPU #2: 3.42 kH/s
+[2023-05-05 21:10:58] CPU #4: 3.43 kH/s
+[2023-05-05 21:11:03] CPU #5: 3.43 kH/s
+[2023-05-05 21:11:03] Total: 20.58 kH/s
+[2023-05-05 21:11:03] CPU #0: 3.33 kH/s
+[2023-05-05 21:11:08] Total: 20.50 kH/s
+[2023-05-05 21:11:08] CPU #3: 3.42 kH/s
+[2023-05-05 21:11:08] CPU #2: 3.42 kH/s
+[2023-05-05 21:11:08] CPU #4: 3.43 kH/s
+[2023-05-05 21:11:08] CPU #1: 3.42 kH/s
+[2023-05-05 21:11:13] CPU #5: 3.43 kH/s
+[2023-05-05 21:11:13] Total: 20.45 kH/s
+[2023-05-05 21:11:13] CPU #0: 3.24 kH/s
+[2023-05-05 21:11:18] CPU #3: 3.43 kH/s
+[2023-05-05 21:11:18] Total: 20.10 kH/s
+[2023-05-05 21:11:18] CPU #1: 3.44 kH/s
+[2023-05-05 21:11:18] CPU #4: 3.44 kH/s
+[2023-05-05 21:11:18] CPU #2: 3.42 kH/s
+[2023-05-05 21:11:23] CPU #5: 3.43 kH/s
+[2023-05-05 21:11:23] Total: 20.59 kH/s
+[2023-05-05 21:11:23] CPU #0: 3.43 kH/s
+[2023-05-05 21:11:28] CPU #3: 3.43 kH/s
+[2023-05-05 21:11:28] Total: 20.61 kH/s
+[2023-05-05 21:11:28] CPU #4: 3.44 kH/s
+[2023-05-05 21:11:28] CPU #1: 3.44 kH/s
+[2023-05-05 21:11:28] CPU #2: 3.42 kH/s
+[2023-05-05 21:11:33] CPU #5: 3.43 kH/s
+[2023-05-05 21:11:33] Total: 20.50 kH/s
+[2023-05-05 21:11:33] CPU #0: 3.34 kH/s
+[2023-05-05 21:11:38] CPU #3: 3.43 kH/s
+[2023-05-05 21:11:38] CPU #4: 3.44 kH/s
+[2023-05-05 21:11:38] CPU #1: 3.42 kH/s
+[2023-05-05 21:11:38] Total: 20.48 kH/s
+[2023-05-05 21:11:38] CPU #2: 3.34 kH/s
+[2023-05-05 21:11:43] CPU #0: 3.43 kH/s
+[2023-05-05 21:11:43] CPU #5: 3.44 kH/s
+[2023-05-05 21:11:43] Total: 20.61 kH/s
+[2023-05-05 21:11:48] CPU #3: 3.43 kH/s
+[2023-05-05 21:11:48] CPU #1: 3.43 kH/s
+[2023-05-05 21:11:48] CPU #4: 3.44 kH/s
+[2023-05-05 21:11:48] CPU #2: 3.34 kH/s
+[2023-05-05 21:11:48] Total: 20.50 kH/s
+[2023-05-05 21:11:53] CPU #0: 3.43 kH/s
+[2023-05-05 21:11:53] CPU #5: 3.43 kH/s
+[2023-05-05 21:11:53] Total: 20.60 kH/s
+[2023-05-05 21:11:58] CPU #3: 3.43 kH/s
+[2023-05-05 21:11:58] CPU #2: 3.43 kH/s
+[2023-05-05 21:11:58] CPU #4: 3.44 kH/s
+[2023-05-05 21:11:58] Total: 20.59 kH/s
+[2023-05-05 21:11:58] CPU #1: 3.34 kH/s
+[2023-05-05 21:11:59] CPU #0: 3.33 kH/s
+[2023-05-05 21:12:04] CPU #5: 3.34 kH/s
+[2023-05-05 21:12:04] Total: 20.49 kH/s
+[2023-05-05 21:12:07] Total: 20.56 kH/s
+[2023-05-05 21:12:08] CPU #3: 3.41 kH/s
+[2023-05-05 21:12:08] CPU #4: 3.44 kH/s
+[2023-05-05 21:12:08] CPU #2: 3.34 kH/s
+[2023-05-05 21:12:08] CPU #1: 3.43 kH/s
+[2023-05-05 21:12:08] CPU #0: 3.41 kH/s
+[2023-05-05 21:12:08] Total: 20.46 kH/s
+[2023-05-05 21:12:14] CPU #0: 3.34 kH/s
+[2023-05-05 21:12:14] CPU #5: 3.35 kH/s
+[2023-05-05 21:12:14] Total: 20.44 kH/s
+[2023-05-05 21:12:17] Total: 20.61 kH/s
+[2023-05-05 21:12:18] CPU #3: 3.34 kH/s
+[2023-05-05 21:12:18] CPU #2: 3.43 kH/s
+[2023-05-05 21:12:18] CPU #1: 3.43 kH/s
+[2023-05-05 21:12:18] CPU #4: 3.44 kH/s
+[2023-05-05 21:12:18] Total: 20.49 kH/s
+[2023-05-05 21:12:23] CPU #5: 3.43 kH/s
+[2023-05-05 21:12:23] Total: 20.59 kH/s
+[2023-05-05 21:12:24] CPU #0: 3.25 kH/s
+[2023-05-05 21:12:28] CPU #3: 3.44 kH/s
+[2023-05-05 21:12:28] CPU #1: 3.43 kH/s
+[2023-05-05 21:12:28] CPU #2: 3.35 kH/s
+[2023-05-05 21:12:28] CPU #4: 3.42 kH/s
+[2023-05-05 21:12:28] Total: 20.50 kH/s
+[2023-05-05 21:12:33] CPU #5: 3.43 kH/s
+[2023-05-05 21:12:33] Total: 20.48 kH/s
+[2023-05-05 21:12:33] CPU #0: 3.41 kH/s
+[2023-05-05 21:12:38] Total: 20.60 kH/s
+[2023-05-05 21:12:38] CPU #3: 3.43 kH/s
+[2023-05-05 21:12:38] CPU #2: 3.43 kH/s
+[2023-05-05 21:12:38] CPU #1: 3.43 kH/s
+[2023-05-05 21:12:38] CPU #4: 3.43 kH/s
+[2023-05-05 21:12:43] CPU #5: 3.43 kH/s
+[2023-05-05 21:12:43] Total: 20.45 kH/s
+[2023-05-05 21:12:43] CPU #0: 3.34 kH/s
+[2023-05-05 21:12:48] Total: 20.52 kH/s
+[2023-05-05 21:12:48] CPU #3: 3.44 kH/s
+[2023-05-05 21:12:48] CPU #2: 3.43 kH/s
+[2023-05-05 21:12:48] CPU #1: 3.43 kH/s
+[2023-05-05 21:12:48] CPU #4: 3.43 kH/s
+[2023-05-05 21:12:53] CPU #5: 3.43 kH/s
+[2023-05-05 21:12:53] Total: 20.50 kH/s
+[2023-05-05 21:12:53] CPU #0: 3.34 kH/s
+[2023-05-05 21:12:58] Total: 20.43 kH/s
+
+Total Scores: 20.61,20.60,20.59,20.58,20.57,20.56,20.55,20.53,20.52,20.50,20.49,20.48,20.47,20.46,20.45,20.44,20.43,20.42,20.40,20.39,20.28,20.10
+
+##########################################################################
+
+Testing maximum cpufreq again, still under full load. System health now:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:12:21: 1510MHz  6.06  99%   0%  98%   0%   0%   0%  51.2°C
+
+Checking cpufreq OPP (Cortex-A78AE):
+
+Cpufreq OPP: 1510    Measured: 1508 (1508.970/1508.694/1508.660)
+
+##########################################################################
+
+Hardware sensors:
+
+ina3221-i2c-1-40
+VDD_IN:                  4.99 V  
+VDD_CPU_GPU_CV:          4.98 V  
+VDD_SOC:                 4.98 V  
+in4:                     5.04 V  
+in5:                   840.00 mV 
+in6:                     1.44 V  
+sum of shunt voltages:   7.16 V  
+curr1:                   1.01 A  (max =  +3.00 A, crit max =  +4.00 A)
+curr2:                 168.00 mA (max = +32.76 A, crit max = +32.76 A)
+curr3:                 288.00 mA (max = +32.76 A, crit max = +32.76 A)
+curr4:                   1.42 A  (crit max = +131.06 A)
+
+##########################################################################
+
+Thermal source: /sys/devices/virtual/thermal/thermal_zone7/ (SOC2-therm)
+
+System health while running tinymembench:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:00:25: 1510MHz  1.46  23%   8%  13%   0%   0%   0%  47.2°C
+21:00:35: 1510MHz  1.39  18%   0%  16%   0%   0%   0%  47.5°C
+21:00:45: 1510MHz  1.33  17%   0%  16%   0%   0%   0%  47.6°C
+21:00:55: 1510MHz  1.28  17%   0%  16%   0%   0%   0%  47.8°C
+21:01:05: 1510MHz  1.38  17%   0%  16%   0%   0%   0%  48.1°C
+21:01:15: 1510MHz  1.32  17%   0%  16%   0%   0%   0%  48.4°C
+21:01:25: 1510MHz  1.27  17%   0%  16%   0%   0%   0%  48.6°C
+21:01:35: 1510MHz  1.23  17%   0%  16%   0%   0%   0%  48.6°C
+21:01:45: 1510MHz  1.20  18%   1%  16%   0%   0%   0%  48.4°C
+21:01:55: 1510MHz  1.16  17%   0%  16%   0%   0%   0%  48.4°C
+
+System health while running ramlat:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:02:05: 1510MHz  1.14  23%   8%  13%   0%   0%   0%  48.3°C
+21:02:08: 1510MHz  1.13  17%   0%  16%   0%   0%   0%  48.3°C
+21:02:11: 1510MHz  1.12  17%   1%  16%   0%   0%   0%  48.2°C
+21:02:14: 1510MHz  1.12  17%   0%  16%   0%   0%   0%  48.3°C
+21:02:17: 1510MHz  1.11  17%   0%  16%   0%   0%   0%  48.3°C
+21:02:20: 1510MHz  1.11  17%   0%  16%   0%   0%   0%  48.2°C
+21:02:23: 1510MHz  1.10  17%   0%  16%   0%   0%   0%  48.2°C
+21:02:27: 1510MHz  1.09  17%   1%  16%   0%   0%   0%  48.2°C
+21:02:30: 1510MHz  1.09  18%   1%  16%   0%   0%   0%  48.2°C
+21:02:33: 1510MHz  1.16  17%   0%  16%   0%   0%   0%  48.1°C
+
+System health while running OpenSSL benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:02:36: 1510MHz  1.16  23%   8%  13%   0%   0%   0%  48.1°C
+21:02:52: 1510MHz  1.12  17%   0%  16%   0%   0%   0%  47.9°C
+21:03:08: 1510MHz  1.31  17%   0%  16%   0%   0%   0%  47.8°C
+21:03:24: 1510MHz  1.32  17%   0%  16%   0%   0%   0%  47.8°C
+21:03:40: 1510MHz  1.25  17%   0%  16%   0%   0%   0%  47.8°C
+21:03:56: 1510MHz  1.19  17%   0%  16%   0%   0%   0%  47.6°C
+21:04:12: 1510MHz  1.14  17%   0%  16%   0%   0%   0%  47.5°C
+
+System health while running 7-zip single core benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:04:24: 1510MHz  1.11  23%   7%  13%   0%   0%   0%  47.5°C
+21:04:29: 1510MHz  1.11  17%   0%  16%   0%   0%   0%  47.6°C
+21:04:34: 1510MHz  1.10  18%   1%  16%   0%   0%   0%  47.6°C
+21:04:39: 1510MHz  1.25  17%   0%  16%   0%   0%   0%  47.5°C
+21:04:45: 1510MHz  1.23  17%   0%  16%   0%   0%   0%  47.6°C
+21:04:50: 1510MHz  1.21  17%   0%  16%   0%   0%   0%  47.6°C
+21:04:55: 1510MHz  1.19  17%   0%  16%   0%   0%   0%  47.5°C
+21:05:00: 1510MHz  1.18  17%   0%  16%   0%   0%   0%  47.6°C
+21:05:05: 1510MHz  1.16  17%   1%  16%   0%   0%   0%  47.7°C
+21:05:10: 1510MHz  1.15  18%   1%  16%   0%   0%   0%  47.6°C
+21:05:15: 1510MHz  1.14  17%   0%  16%   0%   0%   0%  47.7°C
+21:05:21: 1510MHz  1.13  18%   1%  16%   0%   0%   0%  47.5°C
+21:05:26: 1510MHz  1.12  17%   0%  16%   0%   0%   0%  47.6°C
+21:05:31: 1510MHz  1.11  17%   0%  16%   0%   0%   0%  47.7°C
+
+System health while running 7-zip multi core benchmark:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:05:33: 1510MHz  1.10  23%   7%  13%   0%   0%   0%  48.1°C
+21:05:43: 1510MHz  2.01  95%   1%  94%   0%   0%   0%  48.5°C
+21:05:53: 1510MHz  2.85  93%   1%  92%   0%   0%   0%  48.9°C
+21:06:04: 1510MHz  3.26  98%   1%  96%   0%   0%   0%  49.4°C
+21:06:14: 1510MHz  3.84  85%   2%  82%   0%   0%   0%  49.4°C
+21:06:27: 1510MHz  4.18  95%   1%  94%   0%   0%   0%  49.8°C
+21:06:40: 1510MHz  4.50  97%   0%  96%   0%   0%   0%  50.2°C
+21:06:52: 1510MHz  4.73  93%   0%  92%   0%   0%   0%  50.6°C
+21:07:02: 1510MHz  5.08  87%   2%  83%   0%   0%   0%  50.5°C
+21:07:15: 1510MHz  5.30  95%   1%  94%   0%   0%   0%  50.9°C
+21:07:29: 1510MHz  5.41  97%   0%  96%   0%   0%   0%  51.2°C
+21:07:41: 1510MHz  5.61  94%   1%  93%   0%   0%   0%  51.2°C
+21:07:54: 1510MHz  5.30  87%   2%  85%   0%   0%   0%  51.1°C
+
+System health while running cpuminer:
+
+Time        CPU    load %cpu %sys %usr %nice %io %irq   Temp
+21:08:02: 1510MHz  5.48  27%   7%  18%   0%   0%   0%  51.3°C
+21:08:46: 1510MHz  5.80  99%   0%  99%   0%   0%   0%  51.2°C
+21:09:29: 1510MHz  6.14  99%   0%  99%   0%   0%   0%  51.2°C
+21:10:12: 1510MHz  6.10  99%   0%  99%   0%   0%   0%  51.2°C
+21:10:55: 1510MHz  6.09  99%   0%  99%   0%   0%   0%  51.2°C
+21:11:38: 1510MHz  6.04  99%   0%  98%   0%   0%   0%  51.2°C
+21:12:21: 1510MHz  6.06  99%   0%  98%   0%   0%   0%  51.2°C
+
+##########################################################################
+
+Linux 5.10.104-tegra (cale) 	05.05.2023 	_aarch64_	(6 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          26.41    0.26    7.31    0.45    0.00   65.56
+
+Device             tps    kB_read/s    kB_wrtn/s    kB_dscd/s    kB_read    kB_wrtn    kB_dscd
+mmcblk1           1.34        33.49       120.69        14.69    3020957   10885476    1324604
+nvme0n1           0.00         0.12         0.00         0.00      11080          0          0
+zram0             0.05         0.04         0.17         0.00       3548      15620          0
+zram1             0.05         0.04         0.17         0.00       3632      15536          0
+zram2             0.05         0.04         0.17         0.00       3532      15596          0
+zram3             0.05         0.04         0.17         0.00       3724      15056          0
+zram4             0.05         0.04         0.17         0.00       3892      15256          0
+zram5             0.05         0.04         0.17         0.00       3944      15364          0
+
+              total        used        free      shared  buff/cache   available
+Mem:          6.3Gi       2.5Gi       3.3Gi        45Mi       597Mi       3.6Gi
+Swap:         3.2Gi        82Mi       3.1Gi
+
+Filename				Type		Size	Used	Priority
+/dev/zram0                             	partition	553008	14368	5
+/dev/zram1                             	partition	553008	14284	5
+/dev/zram2                             	partition	553008	14408	5
+/dev/zram3                             	partition	553008	13892	5
+/dev/zram4                             	partition	553008	13716	5
+/dev/zram5                             	partition	553008	13776	5
+
+CPU sysfs topology (clusters, cpufreq members, clockspeeds)
+                 cpufreq   min    max
+ CPU    cluster  policy   speed  speed   core type
+  0        0        0      115    1510   Cortex-A78AE / r0p1
+  1        0        0      115    1510   Cortex-A78AE / r0p1
+  2        0        0      115    1510   Cortex-A78AE / r0p1
+  3        0        0      115    1510   Cortex-A78AE / r0p1
+  4        0        4      115    1510   Cortex-A78AE / r0p1
+  5        0        4      115    1510   Cortex-A78AE / r0p1
+
+Architecture:                    aarch64
+CPU op-mode(s):                  32-bit, 64-bit
+Byte Order:                      Little Endian
+CPU(s):                          6
+On-line CPU(s) list:             0-5
+Thread(s) per core:              1
+Core(s) per socket:              6
+Socket(s):                       1
+Vendor ID:                       ARM
+Model:                           1
+Model name:                      ARMv8 Processor rev 1 (v8l)
+Stepping:                        r0p1
+CPU max MHz:                     1510.4000
+CPU min MHz:                     115.2000
+BogoMIPS:                        62.50
+L1d cache:                       384 KiB
+L1i cache:                       384 KiB
+L2 cache:                        1.5 MiB
+L3 cache:                        2 MiB
+Vulnerability Itlb multihit:     Not affected
+Vulnerability L1tf:              Not affected
+Vulnerability Mds:               Not affected
+Vulnerability Meltdown:          Not affected
+Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
+Vulnerability Spectre v2:        Not affected
+Vulnerability Srbds:             Not affected
+Vulnerability Tsx async abort:   Not affected
+Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp uscat ilrcpc flagm
+
+Processor Information
+	Socket Designation: CPU01
+	Type: Central Processor
+	Family: ARMv8
+	ID: 00 00 00 00 01 00 00 00
+	External Clock: 31 MHz
+	Max Speed: 2000 MHz
+	Current Speed: 2000 MHz
+	Status: Populated, Enabled
+	L1 Cache Handle: 0x0001
+	L2 Cache Handle: 0x0002
+	L3 Cache Handle: 0x0003
+	Core Count: 12
+	Core Enabled: 6
+	Thread Count: 1
+	Characteristics:
+		64-bit capable
+		Execute Protection
+
+SoC guess: Nvidia Jetson Orin NX
+DT compat: nvidia,p3768-0000+p3767-0003
+           nvidia,p3768-0000+p3767-0005
+           nvidia,p3767-0003
+           nvidia,p3767-0005
+           nvidia,tegra234
+           nvidia,tegra23x
+ Compiler: /usr/bin/gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0 / aarch64-linux-gnu
+ Userland: arm64
+   Kernel: 5.10.104-tegra/aarch64
+           CONFIG_HZ=250
+           CONFIG_HZ_250=y
+           CONFIG_PREEMPTION=y
+           CONFIG_PREEMPT=y
+           CONFIG_PREEMPT_COUNT=y
+           CONFIG_PREEMPT_NOTIFIERS=y
+           CONFIG_PREEMPT_RCU=y
+
+##########################################################################
+
+Kernel 5.10.104 is not latest 5.10.179 LTS that was released on 2023-04-26.
+
+See https://endoflife.date/linux for details. It is somewhat likely that
+a lot of exploitable vulnerabilities exist for this kernel as well as many
+unfixed bugs.
+
+##########################################################################
+
+Results validation:
+
+  * Measured clockspeed not lower than advertised max CPU clockspeed
+  * No swapping
+  * Background activity (%system) OK
+  * No throttling
+
+Status of performance related governors found below /sys (w/o cpufreq):
+
+  * 154c0000.nvenc: userspace / 115 MHz (nvhost_podgov wmark_active userspace performance simple_ondemand / 115)
+  * 15340000.vic: wmark_active / 435 MHz (nvhost_podgov wmark_active userspace performance simple_ondemand / 115 128 141 154 166 179 192 205 218 230 243 256 269 282 294 307 320 333 346 358 371 384 397 410 422 435)
+  * 15480000.nvdec: userspace / 525 MHz (nvhost_podgov wmark_active userspace performance simple_ondemand / 115 128 141 154 166 179 192 205 218 230 243 256 269 282 294 307 320 333 346 358 371 384 397 410 422 435 448 461 474 486 499 512 525)
+  * 17000000.ga10b: nvhost_podgov / 306 MHz (nvhost_podgov wmark_active userspace performance simple_ondemand / 306 408 510 612 625)
+
+Status of performance related policies found below /sys:
+
+  * /sys/module/pcie_aspm/parameters/policy: default performance powersave [powersupersave]
+
+| NVIDIA Orin Nano Developer Kit | 1510 MHz | 5.10 | Ubuntu 20.04.6 LTS arm64 | 13190 | 2136 | 853580 | 6740 | 20240 | 20.60 |


### PR DESCRIPTION
I adjusted the name a tiny bit from the original "NVIDIA Orin Nano Developer Kit".
In theory there could be differences between the orin nano standalone module (without a fan) and the devkit.
So perhaps "Jetson Orin Nano Developer Kit" would be more fitting.